### PR TITLE
Refactor : pushFrame is replaced with passing argument to evaluation con...

### DIFF
--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/AssociationModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/AssociationModelEvaluator.java
@@ -63,8 +63,7 @@ public class AssociationModelEvaluator extends ModelEvaluator<AssociationModel> 
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = associationModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/ClusteringModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/ClusteringModelEvaluator.java
@@ -49,8 +49,7 @@ public class ClusteringModelEvaluator extends ModelEvaluator<ClusteringModel> im
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = clusteringModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/EvaluationContext.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/EvaluationContext.java
@@ -90,9 +90,7 @@ public class EvaluationContext {
 		Map<FieldName, FieldValue> frame = Maps.newLinkedHashMap();
 
 		frame.putAll(Maps.transformEntries(arguments, transformer));
-
 		getStack().push(frame);
-
 		return frame;
 	}
 

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/FunctionEvaluationContext.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/FunctionEvaluationContext.java
@@ -3,6 +3,8 @@
  */
 package org.jpmml.evaluator;
 
+import java.util.Map;
+
 import org.dmg.pmml.*;
 
 public class FunctionEvaluationContext extends EvaluationContext {
@@ -10,8 +12,9 @@ public class FunctionEvaluationContext extends EvaluationContext {
 	private EvaluationContext parent = null;
 
 
-	public FunctionEvaluationContext(EvaluationContext parent){
+	public FunctionEvaluationContext(EvaluationContext parent, Map<FieldName, FieldValue> arguments){
 		setParent(parent);
+		pushFrame(arguments);
 	}
 
 	@Override

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/FunctionUtil.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/FunctionUtil.java
@@ -67,8 +67,7 @@ public class FunctionUtil {
 			throw new InvalidFeatureException(defineFunction);
 		}
 
-		FunctionEvaluationContext functionContext = new FunctionEvaluationContext(context);
-		functionContext.pushFrame(arguments);
+		FunctionEvaluationContext functionContext = new FunctionEvaluationContext(context, arguments);
 
 		FieldValue result = ExpressionUtil.evaluate(expression, functionContext);
 

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/GeneralRegressionModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/GeneralRegressionModelEvaluator.java
@@ -38,8 +38,7 @@ public class GeneralRegressionModelEvaluator extends ModelEvaluator<GeneralRegre
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = generalRegressionModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/MiningModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/MiningModelEvaluator.java
@@ -46,8 +46,7 @@ public class MiningModelEvaluator extends ModelEvaluator<MiningModel> {
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = miningModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/ModelManagerEvaluationContext.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/ModelManagerEvaluationContext.java
@@ -3,6 +3,8 @@
  */
 package org.jpmml.evaluator;
 
+import java.util.Map;
+
 import org.jpmml.manager.*;
 
 import org.dmg.pmml.*;
@@ -12,8 +14,9 @@ public class ModelManagerEvaluationContext extends EvaluationContext {
 	private ModelManager<?> modelManager = null;
 
 
-	public ModelManagerEvaluationContext(ModelManager<?> modelManager){
+	public ModelManagerEvaluationContext(ModelManager<?> modelManager, Map<FieldName, ?> arguments){
 		setModelManager(modelManager);
+		pushFrame(arguments);
 	}
 
 	@Override

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/NaiveBayesModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/NaiveBayesModelEvaluator.java
@@ -38,8 +38,7 @@ public class NaiveBayesModelEvaluator extends ModelEvaluator<NaiveBayesModel> {
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = naiveBayesModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/NearestNeighborModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/NearestNeighborModelEvaluator.java
@@ -38,8 +38,7 @@ public class NearestNeighborModelEvaluator extends ModelEvaluator<NearestNeighbo
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = nearestNeighborModel.getFunctionName();
 		switch(miningFunction){
@@ -425,7 +424,6 @@ public class NearestNeighborModelEvaluator extends ModelEvaluator<NearestNeighbo
 			}
 		}
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(modelManager);
 
 		KNNInputs knnInputs = nearestNeighborModel.getKNNInputs();
 		for(KNNInput knnInput : knnInputs){
@@ -444,7 +442,7 @@ public class NearestNeighborModelEvaluator extends ModelEvaluator<NearestNeighbo
 					continue;
 				}
 
-				context.pushFrame(rowValues);
+				ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(modelManager, rowValues);
 
 				try {
 					result.put(rowKey, name, ExpressionUtil.evaluate(derivedField, context));

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/NeuralNetworkEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/NeuralNetworkEvaluator.java
@@ -41,8 +41,7 @@ public class NeuralNetworkEvaluator extends ModelEvaluator<NeuralNetwork> implem
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = neuralNetwork.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/RegressionModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/RegressionModelEvaluator.java
@@ -33,8 +33,7 @@ public class RegressionModelEvaluator extends ModelEvaluator<RegressionModel> {
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = regressionModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/RuleSetModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/RuleSetModelEvaluator.java
@@ -35,8 +35,7 @@ public class RuleSetModelEvaluator extends ModelEvaluator<RuleSetModel> {
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = ruleSetModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/ScorecardEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/ScorecardEvaluator.java
@@ -35,8 +35,8 @@ public class ScorecardEvaluator extends ModelEvaluator<Scorecard> {
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
+
 
 		MiningFunctionType miningFunction = scorecard.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/SupportVectorMachineModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/SupportVectorMachineModelEvaluator.java
@@ -44,8 +44,7 @@ public class SupportVectorMachineModelEvaluator extends ModelEvaluator<SupportVe
 
 		Map<FieldName, ?> predictions;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = supportVectorMachineModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/TreeModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/TreeModelEvaluator.java
@@ -41,8 +41,7 @@ public class TreeModelEvaluator extends ModelEvaluator<TreeModel> implements Has
 
 		Node node;
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(this, arguments);
 
 		MiningFunctionType miningFunction = treeModel.getFunctionName();
 		switch(miningFunction){

--- a/pmml-evaluator/src/test/java/org/jpmml/evaluator/CategoricalResidualTest.java
+++ b/pmml-evaluator/src/test/java/org/jpmml/evaluator/CategoricalResidualTest.java
@@ -20,8 +20,7 @@ public class CategoricalResidualTest extends RegressionModelEvaluatorTest {
 		// "For some row in the test data the expected value may be Y"
 		Map<FieldName, ?> arguments = createArguments(evaluator.getTargetField(), "Y");
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(evaluator);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(evaluator, arguments);
 
 		DefaultClassificationMap<String> response = new DefaultClassificationMap<String>();
 		response.put("Y", 0.8d);
@@ -36,8 +35,7 @@ public class CategoricalResidualTest extends RegressionModelEvaluatorTest {
 		// "For some other row the expected value may be N"
 		arguments = createArguments(evaluator.getTargetField(), "N");
 
-		context = new ModelManagerEvaluationContext(evaluator);
-		context.pushFrame(arguments);
+		context = new ModelManagerEvaluationContext(evaluator, arguments);
 
 		result = OutputUtil.evaluate(prediction, context);
 

--- a/pmml-evaluator/src/test/java/org/jpmml/evaluator/ContinuousResidualTest.java
+++ b/pmml-evaluator/src/test/java/org/jpmml/evaluator/ContinuousResidualTest.java
@@ -19,8 +19,7 @@ public class ContinuousResidualTest extends RegressionModelEvaluatorTest {
 
 		Map<FieldName, ?> arguments = createArguments(evaluator.getTargetField(), 3.0d);
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(evaluator);
-		context.pushFrame(arguments);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(evaluator, arguments);
 
 		Map<FieldName, ?> prediction = Collections.singletonMap(evaluator.getTargetField(), 1.0d);
 

--- a/pmml-evaluator/src/test/java/org/jpmml/evaluator/DefaultValueTest.java
+++ b/pmml-evaluator/src/test/java/org/jpmml/evaluator/DefaultValueTest.java
@@ -17,7 +17,7 @@ public class DefaultValueTest extends RegressionModelEvaluatorTest {
 	public void evaluate() throws Exception {
 		RegressionModelEvaluator evaluator = createEvaluator();
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(evaluator);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(evaluator, Collections.<FieldName, Object>emptyMap());
 
 		Map<FieldName, ? extends Number> predictions = TargetUtil.evaluateRegression((Double)null, context);
 

--- a/pmml-evaluator/src/test/java/org/jpmml/evaluator/ExpressionUtilTest.java
+++ b/pmml-evaluator/src/test/java/org/jpmml/evaluator/ExpressionUtilTest.java
@@ -126,15 +126,14 @@ public class ExpressionUtilTest {
 
 	static
 	private EvaluationContext createContext(){
-		EvaluationContext context = new LocalEvaluationContext();
+		EvaluationContext context = new LocalEvaluationContext(Collections.<FieldName, Object>emptyMap());
 
 		return context;
 	}
 
 	static
 	private EvaluationContext createContext(FieldName name, Object value){
-		EvaluationContext context = new LocalEvaluationContext();
-		context.pushFrame(Collections.<FieldName, Object>singletonMap(name, value));
+		EvaluationContext context = new LocalEvaluationContext(Collections.<FieldName, Object>singletonMap(name, value));
 
 		return context;
 	}

--- a/pmml-evaluator/src/test/java/org/jpmml/evaluator/FunctionUtilTest.java
+++ b/pmml-evaluator/src/test/java/org/jpmml/evaluator/FunctionUtilTest.java
@@ -246,7 +246,7 @@ public class FunctionUtilTest {
 			}
 		};
 
-		FieldValue result = apply(function, Lists.newArrayList(Iterables.transform(values, transformer)), new LocalEvaluationContext());
+		FieldValue result = apply(function, Lists.newArrayList(Iterables.transform(values, transformer)), new LocalEvaluationContext(Collections.<FieldName, Object>emptyMap()));
 
 		return FieldValueUtil.getValue(result);
 	}

--- a/pmml-evaluator/src/test/java/org/jpmml/evaluator/LocalEvaluationContext.java
+++ b/pmml-evaluator/src/test/java/org/jpmml/evaluator/LocalEvaluationContext.java
@@ -3,9 +3,15 @@
  */
 package org.jpmml.evaluator;
 
+import java.util.Map;
+
 import org.dmg.pmml.*;
 
 public class LocalEvaluationContext extends EvaluationContext {
+
+	public LocalEvaluationContext(Map<FieldName, Object> arguments) {
+		pushFrame(arguments);
+	}
 
 	@Override
 	public DerivedField resolveField(FieldName name){

--- a/pmml-evaluator/src/test/java/org/jpmml/evaluator/OutputTest.java
+++ b/pmml-evaluator/src/test/java/org/jpmml/evaluator/OutputTest.java
@@ -19,8 +19,7 @@ public class OutputTest extends RegressionModelEvaluatorTest {
 
 		Map<FieldName, ?> predictions = createArguments("result", 8d);
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(regressionModelEvaluator);
-		context.pushFrame(Collections.<FieldName, Object>emptyMap());
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(regressionModelEvaluator, Collections.<FieldName, Object>emptyMap());
 
 		Map<FieldName, ?> result = OutputUtil.evaluate(predictions, context);
 

--- a/pmml-evaluator/src/test/java/org/jpmml/evaluator/PriorProbabilitiesTest.java
+++ b/pmml-evaluator/src/test/java/org/jpmml/evaluator/PriorProbabilitiesTest.java
@@ -17,7 +17,7 @@ public class PriorProbabilitiesTest extends RegressionModelEvaluatorTest {
 	public void evaluate() throws Exception {
 		RegressionModelEvaluator evaluator = createEvaluator();
 
-		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(evaluator);
+		ModelManagerEvaluationContext context = new ModelManagerEvaluationContext(evaluator, Collections.<FieldName, Object>emptyMap());
 
 		Map<FieldName, ? extends ClassificationMap<?>> predictions = TargetUtil.evaluateClassification((ClassificationMap<?>)null, context);
 


### PR DESCRIPTION
I did performance tests and apparently the biggest load is in HashMap.putAll (from pushStackFrame). I'm trying to understand how to workaround this place. 
But first of all, I would like to refactor push/pop relations to see how much it is used. It is a good practice to have matching push and pop methods (and actually for safety reasons, put pop into finally block).

Please review the change and comment it if you feel uncomfortable with it.
